### PR TITLE
Some small patches.

### DIFF
--- a/cl-react.lisp
+++ b/cl-react.lisp
@@ -4,7 +4,9 @@
 
 (cl-react::define-react-function cl-react:create-factory (type))
 
-(cl-react::define-react-function cl-react:render (element container &optional callback))
+;(cl-react::define-react-function cl-react:render (element container &optional callback))
+(defun cl-react:render (element container &optional callback)
+  (chain #:|ReactDOM| (#:render element container callback)))
 
 (cl-react::define-react-function cl-react:unmount-component-at-node (container))
 
@@ -19,14 +21,14 @@
   :nicknames (cl-react:find-dom-node))
 
 (defun cl-react:children-map (fn &optional context)
-  (chain |React| "Children" (map fn context)))
+  (chain #:|React| "Children" (map fn context)))
 
 (defun cl-react:children-for-each (fn &optional context)
-  (chain |React| "Children" (map fn context)))
+  (chain #:|React| "Children" (map fn context)))
 
 (defun cl-react:children-count ()
-  (chain |React| "Children" (count)))
+  (chain #:|React| "Children" (count)))
 
 (defun cl-react:children-only ()
-  (chain |React| "Children" (only)))
+  (chain #:|React| "Children" (only)))
 

--- a/utils.lisp
+++ b/utils.lisp
@@ -5,7 +5,7 @@
 	 (remove-if (lambda (sym) (find sym '(&optional &key))) lambda-list)))
     `(progn
        (defun ,name ,lambda-list
-	 (chain |React| (,name ,@args)))
+         (chain #:|React| (,(make-symbol (string name)) ,@args)))
        ,@(mapcar (lambda (nickname)
 		   `(defun ,nickname ,lambda-list (,name ,@args)))
 		 nicknames))))
@@ -20,4 +20,4 @@
 (defparameter cl-react:with-ps 'with-ps)
 
 (defun build ()
-  (ps-compile-file "./cl-react.lisp"))
+  (ps-compile-file (asdf:system-relative-pathname 'cl-react "cl-react.lisp")))


### PR DESCRIPTION
Hi Helmut,
Your recent psx changes work fine for me. The `(setf (ps:ps-package-prefix :cl-react) "cl_react_")` line in packages.lisp is doing some strange stuff, though. The JS comes out looking like this:

```
function cl_react_createElement(type, cl_react_props, cl_react_children) {
            return cl_react_React.cl_react_createElement(type, cl_react_props, cl_react_children);
```

So it can't find React. I've made a few changes to get it working for now. Alternative: place the React symbol in an unprefixed package and import it into cl-react. That solution felt a bit heavy to me, thought it may be more correct.

Also, my version of React (0.14.2) wanted render to come from ReactDOM. My solution is a bit ham-handed, as you'll see. It might not work for older versions. I was just getting it working for me :-)

Otherwise, it looks good.
Thanks,
Ben
